### PR TITLE
style: adjust latest news style

### DIFF
--- a/components/latest-news.tsx
+++ b/components/latest-news.tsx
@@ -75,7 +75,7 @@ export default function LatestNews() {
         </button>
       </div>
       <div className="mb-6 h-[100px] w-[252px] bg-white p-[10px]">
-        <pre className="size-full overflow-scroll text-wrap text-[15px] leading-[20px]">
+        <pre className="size-full overflow-auto text-wrap text-[15px] leading-[20px]">
           {currentNews.content}
         </pre>
       </div>


### PR DESCRIPTION
- 微調了元件latest-news的一個css：最新消息元件在電腦版瀏覽器會多出scroll bar，導致部分文字被遮蔽，原因是有overflow-scroll的緣故，現在將它改為overflow-auto。

<img width="1911" alt="截圖 2025-01-21 晚上11 25 11" src="https://github.com/user-attachments/assets/005a344c-c682-44a2-a7f0-6844cfa0983b" />

- 有確認過這項改動不會造成手機瀏覽器破版問題。（iPhone15, Safari 18.2)
![IMG_1495](https://github.com/user-attachments/assets/1180a2ad-7be5-4463-83ee-d56ad0c5b2bf)
