### PR TITLE
style: wrong font size on lg breakpoint

### DIFF
--- a/components/landing.tsx
+++ b/components/landing.tsx
@@ -20,7 +20,7 @@ export default function Landing() {
             href={
               'https://docs.google.com/spreadsheets/d/1LTHdDPmihKQlUggj0PzITA44QGlQGgIUSR8D59hWZPI/edit?gid=1224248748#gid=1224248748'
             }
-            className="text-xs text-text-gray underline"
+            className="text-xs text-text-gray underline lg:text-sm"
           >
             此連結
           </NextLink>


### PR DESCRIPTION
- 當螢幕寬度1200px以上時，超連結的文字過小，原因是少加了個tailwind class name
<img width="1220" alt="截圖 2025-01-21 晚上11 51 08" src="https://github.com/user-attachments/assets/a801d631-51fc-4760-85c6-7e7e473716e9" />
