### PR TITLE
feat: add separator in cost

### DIFF
--- a/components/mobile-budget-list.tsx
+++ b/components/mobile-budget-list.tsx
@@ -7,6 +7,14 @@ import { useUserReactionStore } from '@/lib/store'
 import Icon from './icon'
 import { SITE_PATH } from '@/constants/config'
 
+const formatCost = (cost: number | string) => {
+  if (!cost) {
+    return cost
+  }
+  const numberCost = typeof cost === 'number' ? cost : parseInt(cost)
+  return numberCost.toLocaleString()
+}
+
 export default function MobileBudgetList({
   list,
   loadMore,
@@ -79,7 +87,7 @@ const MobileBudgetItem = forwardRef(
           </div>
           <div className="flex w-[30%] max-w-[180px] shrink-0 flex-col gap-4">
             <div className="text-sm font-bold">預算金額</div>
-            <div className="pr-[10px]">{item.cost}</div>
+            <div className="pr-[10px]">{formatCost(item.cost)}</div>
           </div>
           <div className="flex w-14 shrink-0 flex-col gap-4">
             <a className="text-sm underline" href={item.url} target="_blank">


### PR DESCRIPTION
- 在預算金額的地方新增千分分隔符，讓經費更好閱讀
- 因為桌機版改的話會破版（預算金額如果太高的話，會擋到右邊的關心數），所以只改在手機版
- 實測過，320px的螢幕寬度下，並不會破版
- 另外`cost`的型別我看ts定義是number，但實際上拿到的是string，可能要確認一下。

<img width="556" alt="截圖 2025-01-22 凌晨12 16 35" src="https://github.com/user-attachments/assets/e115fc1d-63e7-4a47-89a1-c5e9f3257f68" />
