### PR TITLE
feat: add budget visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # 2025budget
+
+## 在 Local 啟動
+
+1. 環境設定
+首先，請設定環境變數，建立 `.env.local` 檔案，內容如下：
+
+```
+NEXT_PUBLIC_ENV=dev
+NEXT_PUBLIC_DOMAIN=http://localhost:3000
+NEXT_PUBLIC_GCS_BUCKET_PATH=""
+```
+
+2. 安裝相依套件
+```
+yarn install
+```
+
+3. 啟動開發環境
+根據 package.json 的 設定，啟動開發環境
+```
+yarn dev
+```
+這會使用 Next.js 的 turbo mode 啟動開發環境。
+
+4. 存取 local 畫面
+在瀏覽器中開啟：
+```
+http://localhost:3000
+```

--- a/components/budget-list-in-categories.tsx
+++ b/components/budget-list-in-categories.tsx
@@ -3,6 +3,7 @@ import DesktopBudgetTable from './desktop-budget-table'
 import MobileBudgetList from './mobile-budget-list'
 import { BudgetData, CategoryData, CategoryItem } from '@/types/budget'
 import BudgetListControl from './budget-list-control'
+import BudgetVisualization from './budget-visualization'
 import {
   collection,
   DocumentData,
@@ -199,6 +200,7 @@ export default function BudgetListInCategories({
           點我跳轉
         </a>
       </p>
+      <BudgetVisualization list={list} />
       <DesktopBudgetTable list={list} loadMore={fetchNextBudgetList} />
       <MobileBudgetList list={list} loadMore={fetchNextBudgetList} />
     </>

--- a/components/budget-visualization.tsx
+++ b/components/budget-visualization.tsx
@@ -200,7 +200,18 @@ export default function BudgetVisualization({ list }: BudgetVisProps) {
       <div>
         <div className="mb-4">
           <h3 className="text-sm text-gray-500">通過案件分析</h3>
-          <p className="text-xs text-gray-500 mt-1">註：統計資料會隨著頁面捲動更新，請捲動至頁面底部以取得完整統計。</p>
+          <div className="text-xs text-gray-500 space-y-1 mt-1">
+            <p>註：統計資料會隨著頁面捲動更新，請捲動至頁面底部以取得完整統計。</p>
+            <p>
+              註：本次預算審查分為「委員會」和「黨團協商」兩個階段。在委員會中被「保留」的案件，
+              可能在黨團協商時以修改後的版本重新提出。這類案件在統計上會被視為兩個不同的提案，
+              因此「通過案件分析」的數字可能會比實際案件數略高。
+            </p>
+            <p>
+              註：在黨團協商階段，各黨團共提出數千件新提案，但最終多數提案在院會前被撤回。
+              本平台僅收錄進入實質審查的約600件提案，因此實際提案總數會高於此處統計。
+            </p>
+          </div>
         </div>
         <div className="grid grid-cols-3 gap-8">
           {Object.entries(stats).map(([action, stat]) => (

--- a/components/budget-visualization.tsx
+++ b/components/budget-visualization.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react'
+import { BudgetData } from '@/types/budget'
+
+type BudgetVisProps = {
+  list: BudgetData[]
+}
+
+const ACTION_COLORS = {
+  '減列': 'bg-custom-red',
+  '凍結': 'bg-custom-blue',
+  '其他建議': 'bg-text-gray'
+} as const
+
+export default function BudgetVisualization({ list }: BudgetVisProps) {
+  // Filter out items without valid amount and sort by amount
+  const sortedList = useMemo(() => {
+    return list
+      .filter(item => {
+        const amount = parseInt(item.cost)
+        return !isNaN(amount) && amount > 0
+      })
+      .sort((a, b) => {
+        const amountA = parseInt(a.cost) || 0
+        const amountB = parseInt(b.cost) || 0
+        return amountB - amountA
+      })
+  }, [list])
+
+  const maxAmount = useMemo(() => 
+    Math.max(...sortedList.map(item => parseInt(item.cost) || 0)),
+    [sortedList]
+  )
+
+  if (!sortedList.length) {
+    return null
+  }
+
+  return (
+    <div className="w-full max-w-[964px] mt-8 mb-12" role="region" aria-label="預算提案視覺化">
+      <div className="flex flex-col gap-3 mb-6">
+        <div className="flex gap-4 items-center">
+          {Object.entries(ACTION_COLORS).map(([action, color]) => (
+            <div key={action} className="flex items-center gap-2">
+              <div className={`w-4 h-4 ${color}`} role="presentation" />
+              <span>{action}</span>
+            </div>
+          ))}
+        </div>
+        <p className="text-sm text-gray-600">
+          註：顏色較淺代表該提案「保留」，較深代表「通過」
+        </p>
+      </div>
+      
+      <div className="space-y-2">
+        {sortedList.map(item => {
+          const amount = parseInt(item.cost) || 0
+          const width = maxAmount > 0 ? (amount / maxAmount) * 100 : 0
+          const color = ACTION_COLORS[item.action as keyof typeof ACTION_COLORS] || 'bg-text-gray'
+          const opacity = item.result === '通過' ? 'opacity-100' : 'opacity-50'
+          
+          return (
+            <div 
+              key={item.ID} 
+              className="relative group flex items-center gap-2"
+              role="button"
+              tabIndex={0}
+              aria-label={`${item.full_name} - ${item.action} - ${item.cost}元`}
+            >
+              <div className="w-16 text-sm text-right flex-shrink-0">
+                {item.ID}
+              </div>
+              <div className="flex-grow">
+                <div 
+                  className={`h-8 ${color} ${opacity} transition-all`}
+                  style={{ width: `${width}%` }}
+                />
+                <div className="absolute left-20 top-0 h-full flex items-center opacity-0 group-hover:opacity-100 transition-opacity bg-white/80 px-2">
+                  <span className="text-sm whitespace-nowrap">
+                    {item.full_name} - {item.action} - {item.cost}元
+                  </span>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+} 

--- a/components/budget-visualization.tsx
+++ b/components/budget-visualization.tsx
@@ -11,6 +11,13 @@ const ACTION_COLORS = {
   '其他建議': 'bg-text-gray'
 } as const
 
+type ActionStats = {
+  total: number
+  passed: number
+  percentage: number
+  totalAmount: number
+}
+
 export default function BudgetVisualization({ list }: BudgetVisProps) {
   // Filter out items without valid amount and sort by amount
   const sortedList = useMemo(() => {
@@ -31,58 +38,156 @@ export default function BudgetVisualization({ list }: BudgetVisProps) {
     [sortedList]
   )
 
+  // Calculate statistics
+  const stats = useMemo(() => {
+    const initialStats = {
+      '減列': { total: 0, passed: 0, percentage: 0, totalAmount: 0 },
+      '凍結': { total: 0, passed: 0, percentage: 0, totalAmount: 0 },
+      '其他建議': { total: 0, passed: 0, percentage: 0, totalAmount: 0 }
+    } as Record<string, ActionStats>
+
+    // Count all cases including those without valid amounts
+    list.forEach(item => {
+      const action = item.action as keyof typeof ACTION_COLORS
+      const amount = parseInt(item.cost) || 0
+      
+      if (initialStats[action]) {
+        initialStats[action].total++
+        if (item.result === '通過') {
+          initialStats[action].passed++
+        }
+        if (!isNaN(amount) && amount > 0) {
+          initialStats[action].totalAmount += amount
+        }
+      }
+    })
+
+    // Calculate percentages
+    Object.keys(initialStats).forEach(action => {
+      const { total, passed } = initialStats[action]
+      initialStats[action].percentage = total > 0 ? (passed / total) * 100 : 0
+    })
+
+    return initialStats
+  }, [list])
+
   if (!sortedList.length) {
     return null
   }
 
+  const totalAmount = Object.values(stats).reduce((sum, stat) => sum + stat.totalAmount, 0)
+  const totalCases = list.length // Use original list length
+
+  // Format amount in Chinese
+  const formatAmountToChinese = (amount: number) => {
+    if (amount >= 100000000) {
+      return `${(amount / 100000000).toFixed(1)}億`
+    }
+    if (amount >= 10000) {
+      return `${(amount / 10000).toFixed(1)}萬`
+    }
+    return amount.toString()
+  }
+
   return (
     <div className="w-full max-w-[964px] mt-8 mb-12" role="region" aria-label="預算提案視覺化">
-      <div className="flex flex-col gap-3 mb-6">
-        <div className="flex gap-4 items-center">
-          {Object.entries(ACTION_COLORS).map(([action, color]) => (
-            <div key={action} className="flex items-center gap-2">
-              <div className={`w-4 h-4 ${color}`} role="presentation" />
-              <span>{action}</span>
+      {/* Top Stats Row */}
+      <div className="grid grid-cols-2 gap-8 mb-12">
+        {/* Total Cases Card */}
+        <div className="flex flex-col items-start">
+          <h3 className="text-sm text-gray-500 mb-1">總案件數</h3>
+          <p className="text-4xl font-bold">{totalCases}</p>
+        </div>
+
+        {/* Total Amount Card */}
+        <div className="flex flex-col items-end">
+          <h3 className="text-sm text-gray-500 mb-1">總預算</h3>
+          <p className="text-4xl font-bold">
+            {formatAmountToChinese(totalAmount)}元
+          </p>
+        </div>
+      </div>
+
+      {/* Chart Section */}
+      <div className="mb-12">
+        <div className="flex flex-col gap-2 mb-6">
+          <div className="flex gap-6 items-center">
+            {Object.entries(ACTION_COLORS).map(([action, color]) => (
+              <div key={action} className="flex items-center gap-1.5">
+                <div className={`w-3 h-3 ${color}`} role="presentation" />
+                <span className="text-sm">{action}</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500">
+            註：顏色較淺代表該提案「保留」，較深代表「通過」
+          </p>
+        </div>
+        
+        <div className="space-y-1.5">
+          {sortedList.map(item => {
+            const amount = parseInt(item.cost) || 0
+            const width = maxAmount > 0 ? (amount / maxAmount) * 100 : 0
+            const color = ACTION_COLORS[item.action as keyof typeof ACTION_COLORS] || 'bg-text-gray'
+            const opacity = item.result === '通過' ? 'opacity-100' : 'opacity-50'
+            
+            return (
+              <div 
+                key={item.ID} 
+                className="relative group flex items-center gap-3"
+                role="button"
+                tabIndex={0}
+                aria-label={`${item.full_name} - ${item.action} - ${item.cost}元`}
+              >
+                <div className="w-16 text-sm text-right flex-shrink-0 text-gray-500 font-mono">
+                  {item.ID}
+                </div>
+                <div className="flex-grow">
+                  <div 
+                    className={`h-7 ${color} ${opacity} transition-all rounded-sm`}
+                    style={{ width: `${width}%` }}
+                  />
+                  <div className="absolute left-20 top-0 h-full flex items-center opacity-0 group-hover:opacity-100 transition-opacity bg-white/90 px-2">
+                    <span className="text-sm whitespace-nowrap">
+                      {item.full_name} - {item.action} - {item.cost}元
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Analysis Section */}
+      <div>
+        <h3 className="text-sm text-gray-500 mb-6">通過案件分析</h3>
+        <div className="grid grid-cols-3 gap-8">
+          {Object.entries(stats).map(([action, stat]) => (
+            <div key={action} className="relative">
+              <div className="flex items-center gap-2 mb-4">
+                <div className={`w-3 h-3 ${ACTION_COLORS[action as keyof typeof ACTION_COLORS]}`} />
+                <span className="font-medium">{action}</span>
+              </div>
+              <table className="w-full text-sm">
+                <tbody className="space-y-2">
+                  <tr className="flex justify-between py-1">
+                    <td className="text-gray-500">提案</td>
+                    <td className="font-medium">{stat.total}件</td>
+                  </tr>
+                  <tr className="flex justify-between py-1">
+                    <td className="text-gray-500">通過</td>
+                    <td className="font-medium">{stat.passed}件</td>
+                  </tr>
+                  <tr className="flex justify-between py-1">
+                    <td className="text-gray-500">通過比例</td>
+                    <td className="font-medium">{stat.percentage.toFixed(1)}%</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
           ))}
         </div>
-        <p className="text-sm text-gray-600">
-          註：顏色較淺代表該提案「保留」，較深代表「通過」
-        </p>
-      </div>
-      
-      <div className="space-y-2">
-        {sortedList.map(item => {
-          const amount = parseInt(item.cost) || 0
-          const width = maxAmount > 0 ? (amount / maxAmount) * 100 : 0
-          const color = ACTION_COLORS[item.action as keyof typeof ACTION_COLORS] || 'bg-text-gray'
-          const opacity = item.result === '通過' ? 'opacity-100' : 'opacity-50'
-          
-          return (
-            <div 
-              key={item.ID} 
-              className="relative group flex items-center gap-2"
-              role="button"
-              tabIndex={0}
-              aria-label={`${item.full_name} - ${item.action} - ${item.cost}元`}
-            >
-              <div className="w-16 text-sm text-right flex-shrink-0">
-                {item.ID}
-              </div>
-              <div className="flex-grow">
-                <div 
-                  className={`h-8 ${color} ${opacity} transition-all`}
-                  style={{ width: `${width}%` }}
-                />
-                <div className="absolute left-20 top-0 h-full flex items-center opacity-0 group-hover:opacity-100 transition-opacity bg-white/80 px-2">
-                  <span className="text-sm whitespace-nowrap">
-                    {item.full_name} - {item.action} - {item.cost}元
-                  </span>
-                </div>
-              </div>
-            </div>
-          )
-        })}
       </div>
     </div>
   )

--- a/components/budget-visualization.tsx
+++ b/components/budget-visualization.tsx
@@ -161,7 +161,10 @@ export default function BudgetVisualization({ list }: BudgetVisProps) {
 
       {/* Analysis Section */}
       <div>
-        <h3 className="text-sm text-gray-500 mb-6">通過案件分析</h3>
+        <div className="mb-4">
+          <h3 className="text-sm text-gray-500">通過案件分析</h3>
+          <p className="text-xs text-gray-500 mt-1">註：統計資料會隨著頁面捲動更新，請捲動至頁面底部以取得完整統計。</p>
+        </div>
         <div className="grid grid-cols-3 gap-8">
           {Object.entries(stats).map(([action, stat]) => (
             <div key={action} className="relative">

--- a/types/budget.ts
+++ b/types/budget.ts
@@ -44,3 +44,31 @@ export enum BudgetListViewMode {
   Category = '依部會分類',
   Search = '搜尋',
 }
+
+export interface Budget {
+  ID: number
+  time_place: string
+  category: string
+  full_name: string
+  who: string
+  action: string
+  result: string
+  content: string
+  cost: number
+  deleted?: number
+  frozen?: number
+  item: string
+  item_note: string
+  last_cost: string
+  last_budget: string
+  budget_diff: string
+  budget_url: string
+  url: string
+  totalReaction: number
+  reaction?: {
+    happy?: number
+    angry?: number
+    letdown?: number
+    indifferent?: number
+  }
+}


### PR DESCRIPTION
## 修改內容
在 BudgetVisualization 組件中新增、優化了分析區塊的排版與使用者體驗：

- 新增總預算、案件數、每案依金額長條圖

- 重新組織分析區塊的版面配置
  - 將標題和註解文字包裝在獨立的 div 中
  - 調整元素間距，提升整體視覺層級

- 新增使用者提示資訊
  - 加入統計資料更新機制的說明文字
  - 提醒使用者需要捲動至頁面底部才能獲得完整統計資料

## 測試重點
- 確認分析區塊的版面配置正確
- 驗證提示文字清晰可見且易於理解
- 檢查元素間距是否符合設計規範
- 由於不是所有專區都有充分的預算數字，請主要是用「前瞻計畫、國科會、立法院、退輔會」來做檢查，會方便一點。

## 相關 Issue
https://github.com/readr-media/2025budget/issues/5

![image](https://github.com/user-attachments/assets/79f92ac7-7a7a-4007-a2da-0cd3e5ad70fb)
